### PR TITLE
Add ability to specify the base directory to look for node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,9 @@ bash script for ignoring all files in node_modules for Spotlight
 
 this will add ignore to all `node_modules`s in ~ for Spotlight
 
-## Use
-run `sh add-ignore.sh`
+## Usage
+
+./add-ignore.sh [path]
+
+Options:
+  path  Path to start looking for `node_modules` [default: $HOME]

--- a/add-ignore.sh
+++ b/add-ignore.sh
@@ -1,16 +1,17 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 PROGNAME=$(basename $0)
-red=`tput setaf 1`
-green=`tput setaf 2`
-yellow=`tput setaf 3`
-reset=`tput sgr0`
+BASE=${1:-$HOME}
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+yellow=$(tput setaf 3)
+reset=$(tput sgr0)
 
-find ~ -type d -name 'node_modules' | while read dir; do
-  if [ `grep -o "node_modules" <<< "$dir" | grep ""  -c` == 1 ]
-  then
-    if [ -f "$dir/.metadata_never_index" ]
-    then
+set -e
+
+find $BASE -type d -name 'node_modules' | while read dir; do
+  if [[ $(grep -o "node_modules" <<< "$dir" | grep ""  -c) == 1 ]]; then
+    if [ -f "$dir/.metadata_never_index" ]; then
       echo "${PROGNAME}: ${yellow}$dir already has been ignored ${reset}"
     else
       echo "${PROGNAME}: ${green}Adding ignore to $dir ${reset}"


### PR DESCRIPTION
See the updated Usage section of the README.

If you're in a new project, and `add-ignore.sh` is in your path, you can do `add-ignore.sh .` and the script will work on your current working directory much faster than making it go through your whole home.

Also did a bunch of style tweaks for consistency.
- Change all backticks to `$()`
- `==` and `[]` are supposed to be for strings, I think bash's double brackets `[[]]` are "better" but idk
